### PR TITLE
Disable access token remote methods & secure user's APIs using ACLs

### DIFF
--- a/common/mixins/clear-base-acls.js
+++ b/common/mixins/clear-base-acls.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const path = require('path');
+const appRoot = require('app-root-path');
+
+module.exports = (Model) => {
+    // Clear existing ACLs that are built-in the Model's base class.
+    Model.settings.acls.length = 0;
+    
+    // Setup ACLs for this Model where the ACLs are defined in Model.json file
+    
+    // A helper method to 'slugify' model's name in order to get correct model's .JSON filename.
+    // (E.g: Model's name is ElectronicItem. Then slugified Model's name will be electronic-item)
+    const slugify = (name) => {
+        name = name.replace(/^[A-Z]+/, s => s.toLowerCase());
+        return name.replace(/[A-Z]/g, s => '-' + s.toLowerCase());
+    };
+    
+    // Get the path of Model's .json file
+    const configFile = path.join('./common/models', slugify(Model.modelName) + '.json');
+    
+    // Get JSON object defined in .json file through using app-root-path component 
+    // ( run npm install app-root-path --save to include in this project)
+    const config = appRoot.require(configFile);
+    
+    // Check whether the config object is undefined or the expected acls array does not exist  
+    if (!config || !config.acls){
+        console.log('ClearBaseAcls: Failed to load model config from ', configFile);
+        return;
+    }
+    
+    // Apply each acl settings inside the config into Model's acl settings        
+    config.acls.forEach(acl=> Model.settings.acls.push(acl));    
+            
+};

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -3,6 +3,9 @@
 module.exports = (user) => {
 	const userHelper = require('../utility/user-helper');
 	
+    // Disable remote methods
+    userHelper.disableRemoteMethods(user);    
+    
     /**
      * check whether the request is valid or not. 
      */

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -5,6 +5,9 @@
   "options": {
     "validateUpsert": true
   },
+  "mixins":{
+    "ClearBaseAcls": true
+  },
   "properties": {
     "address": {
       "type": "string"
@@ -15,6 +18,66 @@
   },
   "validations": [],
   "relations": {},
-  "acls": [],
+  "acls": [
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "DENY"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$unauthenticated",
+      "permission": "DENY"
+    },
+
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "create"
+    },
+
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "verification"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "resendVerificationCode"
+    },
+
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "confirm"
+    },
+
+    {
+      "principalType": "ROLE",
+      "principalId": "$unauthenticated",
+      "permission": "ALLOW",
+      "property": "login"
+    },
+
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "logout"
+    },
+    
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "resetPassword",
+      "accessType": "EXECUTE"
+    }
+  ],
   "methods": {}
 }

--- a/common/utility/user-helper.js
+++ b/common/utility/user-helper.js
@@ -94,6 +94,21 @@ class UserHelper {
            return next();
        });
     };
+	
+	/**
+	 * Disable remote methods
+	 */
+	static disableRemoteMethods(userModel){
+		// Disable remote methods that related to access tokens. 
+		// Why? Because access token is something that should be managed from within the backend.
+		userModel.disableRemoteMethod('__count__accessTokens', false);
+		userModel.disableRemoteMethod('__create__accessTokens', false);
+		userModel.disableRemoteMethod('__delete__accessTokens', false);
+		userModel.disableRemoteMethod('__destroyById__accessTokens', false);
+		userModel.disableRemoteMethod('__findById__accessTokens', false);
+		userModel.disableRemoteMethod('__get__accessTokens', false);
+		userModel.disableRemoteMethod('__updateById__accessTokens', false);
+	}	
 };
 
 module.exports = UserHelper;

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "mitrais-api-common",
+  "name": "mitmart-api-common",
   "version": "1.0.0",
   "main": "server/server.js",
   "scripts": {
     "start": "node .",
     "pretest": "export NODE_ENV=testing && slc run -d",
-    "test": "mocha --reporter nyan",
-    "posttest": "nsp check && kill $(ps -ax | grep 'sl-run.js --no-detach server/server.js' | awk '{print $1}') && unset NODE_ENV"
+    "test": "mocha --reporter nyan",               
+    "posttest": "nsp check && kill $(ps -ax | grep 'sl-run.js --no-detach .' | awk '{print $1}') && unset NODE_ENV"
   },
   "dependencies": {
+    "app-root-path": "^1.0.0",
     "compression": "^1.0.3",
     "cors": "^2.5.2",
     "helmet": "^1.3.0",


### PR DESCRIPTION
- Renamed ‘mitrais-api-common’ to ‘mitmart-api-common’.
- Changed npm’s posttest script to kill the backend app properly when
  running npm test script.
- Disable remote methods related to accessTokens
- Cleared User’s built in ACLs by using minxins
- Redefined new ACLs to secure the user APIs and allow unauthenticated
  user to access these following remote methods: signup, signin, singout,
  request verification email, reset password
